### PR TITLE
chore: remove prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "watch": "watchify docs/main.js -p browserify-hmr -o docs/bundle.js -dv",
     "start": "node express & npm run watch",
     "browserify": "./node_modules/browserify/bin/cmd.js docs/main.js -o docs/bundle.js",
-    "prepare": "npm run browserify && npm run build",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "test": "npm run lint && NODE_ENV=test ava --verbose",


### PR DESCRIPTION
prepare script is still being called in the npm lifecycle for publish.

This messes with the procedure. removing this script will help the process to succeed