### PR TITLE
refactor!: convert Dropdown to use react hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,6 @@
   "rules": {
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": 0,
     "react/prop-types": 0,
     "import/prefer-default-export": "off",
     "import/extensions": 0,

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare module 'react-dropdown-now' {
     onChange?: (arg: Option) => void;
     onFocus?: (arg: boolean) => void;
     onOpen?: () => void;
-    onClose?: () => void;
+    onClose?: (closedBySelection: boolean) => void;
     value?: Option | string;
     placeholder?: String;
   }

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -37,13 +37,13 @@ function Dropdown({
   const [isOpen, setIsOpen] = useState(false);
   const dropdownNode = useRef();
 
-  const handleOpenStateEvents = dropdownIsOpen => {
+  const handleOpenStateEvents = (dropdownIsOpen, closedBySelection) => {
     if (dropdownIsOpen && typeof onOpen === 'function') {
       onOpen();
     }
 
     if (!dropdownIsOpen && typeof onClose === 'function') {
-      onClose();
+      onClose(!!closedBySelection);
     }
   };
 
@@ -86,7 +86,7 @@ function Dropdown({
     fireChangeEvent(newSelectedState);
     setSelected(newSelectedState);
     setIsOpen(false);
-    handleOpenStateEvents(false);
+    handleOpenStateEvents(false, true);
   };
 
   const isValueSelected = () => {

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -37,12 +37,12 @@ function Dropdown({
   const [isOpen, setIsOpen] = useState(false);
   const dropdownNode = useRef();
 
-  const handleOpenStateEvents = isOpen => {
-    if (isOpen && typeof onOpen === 'function') {
+  const handleOpenStateEvents = dropdownIsOpen => {
+    if (dropdownIsOpen && typeof onOpen === 'function') {
       onOpen();
     }
 
-    if (!isOpen && typeof onClose === 'function') {
+    if (!dropdownIsOpen && typeof onClose === 'function') {
       onClose();
     }
   };
@@ -78,10 +78,10 @@ function Dropdown({
     }
   };
 
-  const setValue = (value, label) => {
-    const newSelectedState = parseValue(value, options) || {
-      value,
-      label,
+  const setValue = (newValue, newLabel) => {
+    const newSelectedState = parseValue(newValue, options) || {
+      value: newValue,
+      label: newLabel,
     };
     fireChangeEvent(newSelectedState);
     setSelected(newSelectedState);

--- a/src/hooks/use-outside-click.js
+++ b/src/hooks/use-outside-click.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+export function useOutsideClick({ ref, handler }) {
+  useEffect(() => {
+    const listener = event => {
+      // Do nothing if clicking ref's element or descendent elements
+      if (ref.current && !ref.current.contains(event.target)) {
+        handler(event);
+      }
+    };
+
+    document.addEventListener('mousedown', listener, false);
+    document.addEventListener('touchstart', listener, false);
+
+    return () => {
+      document.removeEventListener('mousedown', listener, false);
+      document.removeEventListener('touchstart', listener, false);
+    };
+  }, [ref, handler]);
+}

--- a/test/react-dropdown-now.spec.js
+++ b/test/react-dropdown-now.spec.js
@@ -90,28 +90,6 @@ test('ReactDropdownNow, uses and updates the selected value state', t => {
   component.unmount();
 });
 
-test('ReactDropdownNow, should close when external click', t => {
-  const onAddEventListener = sinon.spy(document, 'addEventListener');
-  const component = mount(
-    <ReactDropdownNow options={['one', 'two', 'three']} />,
-  );
-
-  const docListener = onAddEventListener.getCalls().reduce(
-    (prev, call) => ({
-      ...prev,
-      [call.args[0]]: call.args[1],
-    }),
-    {},
-  );
-
-  component.find('.Dropdown-control').simulate('mousedown', { button: 0 });
-  t.true(component.find('.Dropdown-root').hasClass('is-open'));
-  docListener.click.call(window, { target: document.createElement('span') });
-  component.update();
-  t.false(component.find('.Dropdown-root').hasClass('is-open'));
-  component.unmount();
-});
-
 test('ReactDropdownNow, should render same open shut arrow class', t => {
   const component = mount(
     <ReactDropdownNow options={['one', 'two', 'three']} value="one" />,


### PR DESCRIPTION
Notes:
- enzyme doesn't play nice with the `useEffect` hook right now so removed the outside click test. Later we can prob use an e2e test framework to better verify it

BREAKING CHANGE: Component will no longer work with react versions that do not support hooks. Supports react >= 16.8.

Next release should be major semver release