### PR TITLE
refactor: change parseValue to parseOptionsValue

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import Menu from './Menu';
 import { useOutsideClick } from './hooks/use-outside-click';
-import { parseValue } from './helpers';
+import { parseOptionsValue } from './helpers';
 import { DEFAULT_PLACEHOLDER_STRING, BASE_DEFAULT_PROPS } from './constants';
 
 function Dropdown({
@@ -26,7 +26,7 @@ function Dropdown({
   noOptionsDisplay,
 }) {
   const [selected, setSelected] = useState(
-    parseValue(value, options) || {
+    parseOptionsValue(options, value) || {
       label:
         typeof placeholder === 'undefined'
           ? DEFAULT_PLACEHOLDER_STRING
@@ -79,7 +79,7 @@ function Dropdown({
   };
 
   const setValue = (newValue, newLabel) => {
-    const newSelectedState = parseValue(newValue, options) || {
+    const newSelectedState = parseOptionsValue(options, newValue) || {
       value: newValue,
       label: newLabel,
     };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -25,24 +25,31 @@ export const getOptionValue = (option, value = option) => {
   return value;
 };
 
-export const parseValue = (value, options) => {
-  let option;
+export const parseOptionValue = (option, value, optionValue = null) => {
+  if (option.type === 'group') {
+    const match = option.items.filter(item => item.value === value);
+    if (match.length) {
+      return match[0];
+    }
+  } else if (
+    isValidLabelOrValue(option.value)
+      && getOptionValue(option) === value) {
+    return option;
+  }
 
+  return optionValue;
+};
+
+export const parseOptionsValue = (options, value) => {
   if (typeof value === 'string') {
-    for (let i = 0, num = options.length; i < num; i++) {
-      if (options[i].type === 'group') {
-        const match = options[i].items.filter(item => item.value === value);
-        if (match.length) {
-          [ option ] = match;
-        }
-      } else if (
-        typeof options[i].value !== 'undefined' &&
-        options[i].value === value
-      ) {
-        option = options[i];
+    for (let i = options.length, optionValue; i--;) {
+      optionValue = parseOptionValue(options[i], value);
+
+      if (optionValue !== null) {
+        return optionValue;
       }
     }
   }
 
-  return option || value;
+  return value;
 };

--- a/test/react-dropdown-now-helpers.spec.js
+++ b/test/react-dropdown-now-helpers.spec.js
@@ -1,13 +1,13 @@
 import test from 'ava';
 
-import { parseValue } from '../src/helpers';
+import { parseOptionsValue } from '../src/helpers';
 
-test('parseValue("value", []), should return "value"', t => {
-  t.is(parseValue('value', []), 'value');
+test('parseOptionsValue("value", []), should return "value"', t => {
+  t.is(parseOptionsValue([], 'value'), 'value');
 });
 
-test('parseValue("value 2", […]), should return value 2 item', t => {
-  t.deepEqual(parseValue('value 2', [ {
+test('parseOptionsValue("value 2", […]), should return value 2 item', t => {
+  t.deepEqual(parseOptionsValue([ {
     type: 'group',
     items: [ {
       label: 'group label',
@@ -16,14 +16,14 @@ test('parseValue("value 2", […]), should return value 2 item', t => {
   }, {
     label: 'label 2',
     value: 'value 2'
-  } ]), {
+  } ], 'value 2'), {
     label: 'label 2',
     value: 'value 2'
   });
 });
 
-test('parseValue("group value", […]), should return group value item', t => {
-  t.deepEqual(parseValue('group value', [ {
+test('parseOptionsValue("group value", […]), should return group value item', t => {
+  t.deepEqual(parseOptionsValue([ {
     type: 'group',
     items: [ {
       label: 'group label',
@@ -32,14 +32,14 @@ test('parseValue("group value", […]), should return group value item', t => {
   }, {
     label: 'label 2',
     value: 'value 2'
-  } ]), {
+  } ], 'group value'), {
     label: 'group label',
     value: 'group value'
   });
 });
 
-test('parseValue("no value", […]), should return "no value"', t => {
-  t.deepEqual(parseValue('no value', [ {
+test('parseOptionsValue("no value", […]), should return "no value"', t => {
+  t.deepEqual(parseOptionsValue([ {
     type: 'group',
     items: [ {
       label: 'group label',
@@ -48,5 +48,5 @@ test('parseValue("no value", […]), should return "no value"', t => {
   }, {
     label: 'label 2',
     value: 'value 2'
-  } ]), 'no value');
+  } ], 'no value'), 'no value');
 });


### PR DESCRIPTION
This changes the parseValue's function signature: parseValue(value, options) becomes parseOptionsValue(options, value). This also breaks parseValue into two separate functions.