### PR TITLE
feat: add view property to option object

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const options = [
 
 ```JavaScript
 const options = [
-  { value: 'one', label: 'One' },
+  { value: 'one', label: 'One', view: <span>One</span> },
   { value: 'two', label: 'Two', className: 'myOptionClassName' },
   {
    type: 'group', name: 'group1', items: [
@@ -61,7 +61,10 @@ const options = [
 ];
 ```
 
-When using Object options you can add to each option a className string to further customize the dropdown, e.g. adding icons to options
+When using Object options you can add to each option:
+
+- a `className` string to further customize the dropdown, e.g. adding icons to options
+- a `view` node to render an isolated view in the dropdown options list which is different from what could be seen in the dropdown control (selected value)
 
 **Disabled**
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ declare module 'react-dropdown-now' {
   import * as React from 'react';
   export interface Option {
     label: React.ReactNode;
+    view: React.ReactNode;
     value: string;
     className?: string;
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,17 @@
-export const isValidLabelOrValue = value =>
+export const isValidLabelOrValue = (value) =>
   /string|boolean|number/.test(typeof value);
 
-export const getOptionName = option => option.name;
+export const getOptionName = (option) => option.name;
 
 export const getOptionLabel = (option, label = option) => {
+  if (!option) {
+    return option;
+  }
+
+  if (option.view) {
+    return option.view;
+  }
+
   if (isValidLabelOrValue(option.label)) {
     return option.label;
   }
@@ -29,13 +37,14 @@ export const getOptionValue = (option, value = option) => {
 
 export const parseOptionValue = (option, value, optionValue = null) => {
   if (option.type === 'group') {
-    const match = option.items.filter(item => item.value === value);
+    const match = option.items.filter((item) => item.value === value);
     if (match.length) {
       return match[0];
     }
   } else if (
-    isValidLabelOrValue(option.value)
-      && getOptionValue(option) === value) {
+    isValidLabelOrValue(option.value) &&
+    getOptionValue(option) === value
+  ) {
     return option;
   }
 
@@ -44,7 +53,7 @@ export const parseOptionValue = (option, value, optionValue = null) => {
 
 export const parseOptionsValue = (options, value) => {
   if (typeof value === 'string') {
-    for (let i = options.length, optionValue; i--;) {
+    for (let i = options.length, optionValue; i--; ) {
       optionValue = parseOptionValue(options[i], value);
 
       if (optionValue !== null) {

--- a/test/react-dropdown-now-option.spec.js
+++ b/test/react-dropdown-now-option.spec.js
@@ -5,21 +5,21 @@ import { mount } from 'enzyme';
 
 import Option from '../src/components/Option';
 
-test('ReactDropdownNow.option, renders a string option', t => {
+test('ReactDropdownNow.option, renders a string option', (t) => {
   const component = mount(<Option option="one" />);
 
   t.is(component.text(), 'one');
   t.false(component.find('.Dropdown-option').hasClass('is-selected'));
 });
 
-test('ReactDropdownNow.option, renders a string option, selected', t => {
+test('ReactDropdownNow.option, renders a string option, selected', (t) => {
   const component = mount(<Option option="one" selected="one" />);
 
   t.is(component.text(), 'one');
   t.true(component.find('.Dropdown-option').hasClass('is-selected'));
 });
 
-test('ReactDropdownNow.option, renders an object option', t => {
+test('ReactDropdownNow.option, renders an object option', (t) => {
   const component = mount(
     <Option option={{ label: 'label', value: 'value' }} />,
   );
@@ -28,7 +28,7 @@ test('ReactDropdownNow.option, renders an object option', t => {
   t.false(component.find('.Dropdown-option').hasClass('is-selected'));
 });
 
-test('ReactDropdownNow.option, renders an object option, selected', t => {
+test('ReactDropdownNow.option, renders an object option, selected', (t) => {
   const component = mount(
     <Option option={{ label: 'label', value: 'value' }} selected="value" />,
   );
@@ -37,7 +37,7 @@ test('ReactDropdownNow.option, renders an object option, selected', t => {
   t.true(component.find('.Dropdown-option').hasClass('is-selected'));
 });
 
-test('ReactDropdownNow.option, emits onSelect event', t => {
+test('ReactDropdownNow.option, emits onSelect event', (t) => {
   const onSelect = sinon.spy();
   const component = mount(<Option option="option" onSelect={onSelect} />);
 
@@ -50,4 +50,18 @@ test('ReactDropdownNow.option, emits onSelect event', t => {
   t.is(event.type, 'mousedown');
   t.is(value, 'option');
   t.is(label, 'option');
+});
+
+test('ReactDropdownNow.option, uses view property when set', (t) => {
+  const component = mount(
+    <Option
+      option={{
+        label: 'label',
+        value: 'value',
+        view: <span className="tester">test</span>,
+      }}
+    />,
+  );
+
+  t.is(component.find('.Dropdown-option').text(), 'test');
 });

--- a/test/react-dropdown-now.spec.js
+++ b/test/react-dropdown-now.spec.js
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import ReactDropdownNow from '../src';
 import Menu from '../src/components/Menu';
 
-test('ReactDropdownNow, opens', t => {
+test('ReactDropdownNow, opens', (t) => {
   const onOpen = sinon.spy();
   const component = mount(
     <ReactDropdownNow
@@ -22,7 +22,7 @@ test('ReactDropdownNow, opens', t => {
   component.unmount();
 });
 
-test('ReactDropdownNow, calls onChange', t => {
+test('ReactDropdownNow, calls onChange', (t) => {
   const onOpen = sinon.spy();
   const onClose = sinon.spy();
   const onChange = sinon.spy();
@@ -38,10 +38,7 @@ test('ReactDropdownNow, calls onChange', t => {
 
   component.find('.Dropdown-control').simulate('mousedown', { button: 0 });
 
-  component
-    .find('.Dropdown-option')
-    .at(2)
-    .simulate('mousedown', { button: 0 });
+  component.find('.Dropdown-option').at(2).simulate('mousedown', { button: 0 });
 
   t.true(onOpen.calledOnce);
   t.true(onChange.calledOnce);
@@ -50,7 +47,7 @@ test('ReactDropdownNow, calls onChange', t => {
   component.unmount();
 });
 
-test('ReactDropdownNow, uses and updates the selected value state', t => {
+test('ReactDropdownNow, uses and updates the selected value state', (t) => {
   const onOpen = sinon.spy();
   const component = mount(
     <ReactDropdownNow
@@ -62,13 +59,7 @@ test('ReactDropdownNow, uses and updates the selected value state', t => {
 
   component.find('.Dropdown-control').simulate('mousedown', { button: 0 });
 
-  t.is(
-    component
-      .find(Menu)
-      .find('.Dropdown-option.is-selected')
-      .text(),
-    'one',
-  );
+  t.is(component.find(Menu).find('.Dropdown-option.is-selected').text(), 'one');
   t.true(component.find('.Dropdown-root').hasClass('is-open'));
 
   component
@@ -80,17 +71,14 @@ test('ReactDropdownNow, uses and updates the selected value state', t => {
   component.find('.Dropdown-control').simulate('mousedown', { button: 0 });
   t.true(component.find('.Dropdown-root').hasClass('is-open'));
   t.is(
-    component
-      .find(Menu)
-      .find('.Dropdown-option.is-selected')
-      .text(),
+    component.find(Menu).find('.Dropdown-option.is-selected').text(),
     'three',
   );
 
   component.unmount();
 });
 
-test('ReactDropdownNow, should render same open shut arrow class', t => {
+test('ReactDropdownNow, should render same open shut arrow class', (t) => {
   const component = mount(
     <ReactDropdownNow options={['one', 'two', 'three']} value="one" />,
   );
@@ -100,7 +88,7 @@ test('ReactDropdownNow, should render same open shut arrow class', t => {
   t.true(component.exists('.Dropdown-arrow'));
 });
 
-test('ReactDropdownNow, should render custom open shut arrow elems', t => {
+test('ReactDropdownNow, should render custom open shut arrow elems', (t) => {
   const arrowClosedElem = <span className="arrow-closed" />;
   const arrowOpenedElem = <span className="arrow-opened" />;
   const component = mount(
@@ -119,7 +107,7 @@ test('ReactDropdownNow, should render custom open shut arrow elems', t => {
   t.true(component.exists('.Dropdown-arrow-wrapper > .arrow-opened'));
 });
 
-test('ReactDropdownNow, should render custom open shut arrow classNames', t => {
+test('ReactDropdownNow, should render custom open shut arrow classNames', (t) => {
   const component = mount(
     <ReactDropdownNow
       options={['one', 'two', 'three']}
@@ -133,7 +121,7 @@ test('ReactDropdownNow, should render custom open shut arrow classNames', t => {
   t.true(component.exists('.Dropdown-arrow-wrapper > .arrow-class'));
 });
 
-test('ReactDropdownNow, should render custom option classNames', t => {
+test('ReactDropdownNow, should render custom option classNames', (t) => {
   const component = mount(
     <ReactDropdownNow
       options={[
@@ -161,7 +149,7 @@ test('ReactDropdownNow, should render custom option classNames', t => {
   t.true(menu.exists('.Dropdown-group > .group-item'));
 });
 
-test('ReactDropdownNow, should render menuClassName', t => {
+test('ReactDropdownNow, should render menuClassName', (t) => {
   const component = mount(
     <ReactDropdownNow
       menuClassName="menu-class"
@@ -188,7 +176,7 @@ test('ReactDropdownNow, should render menuClassName', t => {
   t.true(component.exists('.Dropdown-menu.menu-class'));
 });
 
-test('ReactDropdownNow, should render placeholderClassName', t => {
+test('ReactDropdownNow, should render placeholderClassName', (t) => {
   const component = mount(
     <ReactDropdownNow
       placeholderClassName="placeholder-class"
@@ -215,10 +203,7 @@ test('ReactDropdownNow, should render placeholderClassName', t => {
     ),
   );
   component.find('.Dropdown-control').simulate('mousedown', { button: 0 });
-  component
-    .find('.Dropdown-option')
-    .at(1)
-    .simulate('mousedown', { button: 0 });
+  component.find('.Dropdown-option').at(1).simulate('mousedown', { button: 0 });
   t.true(
     component.exists(
       '.Dropdown-control > .Dropdown-placeholder.placeholder-class.is-selected',
@@ -226,7 +211,7 @@ test('ReactDropdownNow, should render placeholderClassName', t => {
   );
 });
 
-test('ReactDropdownNow, should render controlClassName', t => {
+test('ReactDropdownNow, should render controlClassName', (t) => {
   const component = mount(
     <ReactDropdownNow
       controlClassName="control-class"
@@ -252,7 +237,7 @@ test('ReactDropdownNow, should render controlClassName', t => {
   t.true(component.exists('.Dropdown-root > .Dropdown-control.control-class'));
 });
 
-test('ReactDropdownNow, should render className', t => {
+test('ReactDropdownNow, should render className', (t) => {
   const component = mount(
     <ReactDropdownNow
       className="root-class"
@@ -276,4 +261,36 @@ test('ReactDropdownNow, should render className', t => {
   t.true(component.exists('.Dropdown-root.root-class'));
   component.find('.Dropdown-control').simulate('mousedown', { button: 0 });
   t.true(component.exists('.Dropdown-root.root-class'));
+});
+
+test('ReactDropdownNow, uses label property even when view is set', (t) => {
+  const component = mount(
+    <ReactDropdownNow
+      className="root-class"
+      options={[
+        {
+          label: 'label',
+          value: 'value',
+          view: <span className="tester">test</span>,
+        },
+        { value: 'item', label: 'item', className: 'item' },
+        {
+          type: 'group',
+          name: 'group',
+          items: [
+            {
+              value: 'group item',
+              label: 'group item',
+              className: 'group-item',
+            },
+          ],
+        },
+      ]}
+    />,
+  );
+
+  component.find('.Dropdown-control').simulate('mousedown', { button: 0 });
+
+  t.true(component.exists('.Dropdown-option .tester'));
+  t.false(component.exists('.Dropdown-control .tester'));
 });


### PR DESCRIPTION
in some use cases due to the label being copied into the dropdown control, its hard to isolate the views especially when you want to render something different in the option menu versus what is seen in the dropdown control

adding view prop to isolate in this use case