### PR TITLE
feat: add support for controlled component

### DIFF
--- a/docs/controlledExample.js
+++ b/docs/controlledExample.js
@@ -1,0 +1,51 @@
+import React, { Component } from 'react';
+import Dropdown from '../src';
+
+const options = ['one', 'two', 'three'];
+
+class ControlledExample extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selected: '',
+    };
+    this._onSelect = this._onSelect.bind(this);
+  }
+
+  _onSelect(option) {
+    console.log('You selected ', option.label);
+    this.setState({ selected: option });
+  }
+
+  render() {
+    const selectedOption = this.state.selected;
+    const placeHolderValue =
+      typeof this.state.selected === 'string'
+        ? this.state.selected
+        : this.state.selected.label;
+
+    return (
+      <section>
+        <h3>Controlled Example </h3>
+        <Dropdown
+          options={options}
+          onChange={this._onSelect}
+          value={selectedOption}
+          placeholder="Select an option"
+        />
+        <Dropdown
+          options={options}
+          onChange={this._onSelect}
+          value={selectedOption}
+          placeholder="Select an option"
+        />
+        <div className="result">
+          These dropdowns share the selected value
+          <strong> {placeHolderValue} </strong>
+        </div>
+      </section>
+    );
+  }
+}
+
+export default ControlledExample;

--- a/docs/main.js
+++ b/docs/main.js
@@ -6,6 +6,7 @@ import ObjectArrayExample from './objectArrayExample';
 import ZeroValObjectArrayExample from './zeroValObjectArrayExample';
 import CustomArrowExample from './customArrowExample';
 import SelectionObjectArrayExample from './selectionObjectArrayExample';
+import ControlledExample from './controlledExample';
 
 const reactDropdownNowUrl = '//github.com/iambumblehead/react-dropdown-now';
 const reactDropdownUrl = '//github.com/fraserxu/react-dropdown';
@@ -50,6 +51,7 @@ class App extends Component {
         <ZeroValObjectArrayExample />
         <CustomArrowExample />
         <SelectionObjectArrayExample />
+        <ControlledExample />
 
         <section>
           <h3>License: MIT</h3>

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
+import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import classNames from 'classnames';
 import get from 'lodash/get';
 

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -88,8 +88,10 @@ function Dropdown({
 
   const updateValue = useCallback((val) => {
     const newValue = findSelected(options, val, matcher);
-    fireChangeEvent(newValue);
-    setSelected(newValue);
+    if (newValue) {
+      fireChangeEvent(newValue);
+      setSelected(newValue);
+    }
   }, [options, matcher]);
 
   useEffect(() => updateValue(value), [value]);

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo } from 'react';
+import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import classNames from 'classnames';
 import get from 'lodash/get';
 
@@ -85,6 +85,14 @@ function Dropdown({
     setIsOpen(false);
     handleOpenStateEvents(false, true);
   };
+
+  const updateValue = useCallback((val) => {
+    const newValue = findSelected(options, val, matcher);
+    fireChangeEvent(newValue);
+    setSelected(newValue);
+  }, [options, matcher]);
+
+  useEffect(() => updateValue(value), [value]);
 
   const isValueSelected = () => {
     return !!selected;


### PR DESCRIPTION
**Issue**

Current implementation does not update selected option when `value` prop is changed.

**Solution**

- This PR makes the component update selected option when the prop is changed.
- This PR does not affect existing code (unless the prop is changed).

**Demonstration**

The controlled example is available at the bottom of this page: https://arcatdmz.github.io/react-dropdown-now/